### PR TITLE
Mention ThinkTank (CTO role) in homepage "About me"

### DIFF
--- a/src/site/index.html
+++ b/src/site/index.html
@@ -50,9 +50,7 @@ quote: "Taking complicated topics and explaining them in a simple and straightfo
                     It's a messy and unstructured process but when I’m finally done, it gives me satisfaction knowing that I've helped people to understand new topics.
                 </p>
 
-                <p>These days though, most of my time goes into <a href="https://think-tank.io" rel="noopener" target="_blank">ThinkTank</a>, where I'm CTO. It's an AI workspace for businesses: you can use any model you like, record your meetings, and it gets to know your company over time &ndash; what you do and how you write. And because it's completely hosted in the EU, your data stays where it should. It's a lot of fun to build, but I won't lie: it eats up nearly all my time these days.</p>
-
-                <p>I hope that you can feel all my passion when reading my blog posts or watching my videos. A lot of hard work has gone into them!</p>
+                <p>If you've noticed things are a little quieter around here lately, that's because I'm CTO of <a href="https://think-tank.io" rel="noopener" target="_blank">ThinkTank</a> and it takes up nearly all of my time. We're building an AI workspace for businesses: you can use any model you like, record your meetings, and it gradually learns your business &ndash; what you do and how you write. And it's all hosted in the EU.</p>
                     
                 <p>But enough about me! Let's talk about you. What is your story? What drives you? What gets you up in the morning? Is it the Simply Explained content or something else?</p>
                     

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -50,6 +50,8 @@ quote: "Taking complicated topics and explaining them in a simple and straightfo
                     It's a messy and unstructured process but when I’m finally done, it gives me satisfaction knowing that I've helped people to understand new topics.
                 </p>
 
+                <p>These days though, most of my time goes into <a href="https://think-tank.io" rel="noopener" target="_blank">ThinkTank</a>, where I'm CTO. It's an AI workspace for businesses: you can use any model you like, record your meetings, and it gets to know your company over time &ndash; what you do and how you write. And because it's completely hosted in the EU, your data stays where it should. It's a lot of fun to build, but I won't lie: it eats up nearly all my time these days.</p>
+
                 <p>I hope that you can feel all my passion when reading my blog posts or watching my videos. A lot of hard work has gone into them!</p>
                     
                 <p>But enough about me! Let's talk about you. What is your story? What drives you? What gets you up in the morning? Is it the Simply Explained content or something else?</p>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds a short, natural paragraph to the "About me" section on the homepage mentioning that I'm CTO of [ThinkTank](https://think-tank.io) and that it consumes nearly all my time.

The paragraph briefly describes ThinkTank as an AI workspace for businesses (use any model, record meetings, personalized to your business, fully EU-hosted) without being sales-y or pushy. The link opens in a new tab using the existing `rel="noopener" target="_blank"` convention used elsewhere on the site.

See the chat for a few alternative variations of the wording.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-54135af9-1a28-4fe5-9d54-7880d7aa1a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-54135af9-1a28-4fe5-9d54-7880d7aa1a28"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

